### PR TITLE
fix: Add HuggingFace token support and replace missing SD 2.1 model

### DIFF
--- a/.github/actions/tests/action.yml
+++ b/.github/actions/tests/action.yml
@@ -29,6 +29,10 @@ inputs:
   ref:
     description: "Git reference to checkout"
     default: ${{ github.sha }}
+  huggingface-token:
+    description: "HuggingFace Hub API token for model downloads"
+    required: false
+    default: ""
 
 
 runs:
@@ -43,5 +47,7 @@ runs:
 
     - name: Run CPU tests ${{ inputs.pytorch-dtype }}
       shell: bash -l {0}
+      env:
+        HF_TOKEN: ${{ inputs.huggingface-token }}
       run: |
         pytest -v ./tests/ --device=${{ inputs.pytorch-device }} --dtype=${{ inputs.pytorch-dtype }} ${{ inputs.pytest-extra }}

--- a/.github/workflows/self-tests.yml
+++ b/.github/workflows/self-tests.yml
@@ -37,6 +37,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - uses: ./.github/actions/tests/
+        with:
+          huggingface-token: ${{ secrets.HUGGING_FACE_HUB_TOKEN }}
 
   workflow-tests:
     uses: ./.github/workflows/tests.yml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         exclude: ^$|.devcontainer
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.4
+    rev: v0.14.9
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,8 @@ Everyone is welcome to get involved with the project. There are different ways t
 1. Ask/Answer questions:
     - Where can you ask questions?
       1. using the GitHub discussion at Kornia repo: [GH Discussions](https://github.com/kornia/kornia/discussions)
-      2. Our Slack workspace to keep in touch with our core contributors and the community:
-         [Join Here](https://join.slack.com/t/kornia/shared_invite/zt-csobk21g-2AQRi~X9Uu6PLMuUZdvfjA)
-      3. using the `#kornia` tag in [PyTorch Discuss](https://discuss.pytorch.org)
-      4. using Discord Link [Join Discord](https://discord.gg/HfnywwpBnD)
+      2. using the `#kornia` tag in [PyTorch Discuss](https://discuss.pytorch.org)
+      3. using Discord Link [Join Discord](https://discord.gg/HfnywwpBnD)
     - Please, don't use GitHub issues for Q&A.
     - In case you are a developer and want to learn more about the PyTorch ecosystem, we suggest you join the PyTorch
       slack. You can apply using this form: [https://bit.ly/ptslack](https://bit.ly/ptslack)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,7 @@ Everyone is welcome to get involved with the project. There are different ways t
       2. Our Slack workspace to keep in touch with our core contributors and the community:
          [Join Here](https://join.slack.com/t/kornia/shared_invite/zt-csobk21g-2AQRi~X9Uu6PLMuUZdvfjA)
       3. using the `#kornia` tag in [PyTorch Discuss](https://discuss.pytorch.org)
+      4. using Discord Link [Join Discord](https://discord.gg/HfnywwpBnD)
     - Please, don't use GitHub issues for Q&A.
     - In case you are a developer and want to learn more about the PyTorch ecosystem, we suggest you join the PyTorch
       slack. You can apply using this form: [https://bit.ly/ptslack](https://bit.ly/ptslack)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ English | [简体中文](README_zh-CN.md)
 [![star](https://gitcode.com/kornia/kornia/star/badge.svg)](https://gitcode.com/kornia/kornia)
 [![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/HfnywwpBnD)
 [![Twitter](https://img.shields.io/twitter/follow/kornia_foss?style=social)](https://twitter.com/kornia_foss)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENCE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 </p>
 </div>

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -22,7 +22,7 @@
 [![star](https://gitcode.com/kornia/kornia/star/badge.svg)](https://gitcode.com/kornia/kornia)
 [![Discord](https://img.shields.io/badge/Discord-5865F2?logo=discord&logoColor=white)](https://discord.gg/HfnywwpBnD)
 [![Twitter](https://img.shields.io/twitter/follow/kornia_foss?style=social)](https://twitter.com/kornia_foss)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENCE)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 </p>
 </div>

--- a/docs/generate_examples.py
+++ b/docs/generate_examples.py
@@ -382,7 +382,7 @@ def main():
 
     # korna.color.colormap
     colormaps_list = {"AUTUMN": (256,)}
-    bar_img_gray = torch.range(0, 255).repeat(1, 40, 1)  # 1x1x40x256
+    bar_img_gray = torch.arange(0, 256).repeat(1, 40, 1)  # 1x1x40x256
     bar_img = K.color.grayscale_to_rgb(bar_img_gray)
     # ITERATE OVER THE COLORMAPS
     for colormap_name, args in colormaps_list.items():

--- a/docs/source/augmentation.container.rst
+++ b/docs/source/augmentation.container.rst
@@ -63,6 +63,7 @@ scenarios. Understanding when to use each prevents common pitfalls in vision
 pipelines.
 
 **Use ``AugmentationSequential`` when:**
+
 - The task requires synchronized transformations across multiple related tensors
   (images, masks, bounding boxes, keypoints).
 - Spatial correspondence must be maintained between inputs and targets, as in
@@ -71,6 +72,7 @@ pipelines.
   parameter sampling across all targets.
 
 **Use ``ImageSequential`` when:**
+
 - The pipeline only processes image tensors without auxiliary spatial targets.
 - The workflow combines augmentation modules with general image processing
   operations (gaussian blur, edge detection, color transforms).

--- a/docs/source/augmentation.container.rst
+++ b/docs/source/augmentation.container.rst
@@ -54,6 +54,66 @@ mix usage of both image processing and augmentation modules.
 
    .. automethod:: forward
 
+Differences Between ImageSequential and AugmentationSequential
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ImageSequential`` and ``AugmentationSequential`` are both pipeline containers
+in Kornia, but they're designed for fundamentally different data handling
+scenarios. Understanding when to use each prevents common pitfalls in vision
+pipelines.
+
+**Use ``AugmentationSequential`` when:**
+- The task requires synchronized transformations across multiple related tensors
+  (images, masks, bounding boxes, keypoints).
+- Spatial correspondence must be maintained between inputs and targets, as in
+  semantic segmentation or object detection workflows.
+- Multiple data formats need to be handled automatically with consistent random
+  parameter sampling across all targets.
+
+**Use ``ImageSequential`` when:**
+- The pipeline only processes image tensors without auxiliary spatial targets.
+- The workflow combines augmentation modules with general image processing
+  operations (gaussian blur, edge detection, color transforms).
+- A lightweight container is preferred without the overhead of multi-target
+  synchronization logic.
+
+Example using ``ImageSequential``::
+
+    import torch
+    import kornia.augmentation as K
+    from kornia.augmentation.container import ImageSequential
+    from kornia.filters import gaussian_blur2d
+
+    img = torch.rand(1, 3, 256, 256)
+
+    seq = ImageSequential(
+        K.RandomHorizontalFlip(p=1.0),
+        gaussian_blur2d,  # arbitrary differentiable ops can be inserted
+    )
+
+    out = seq(img)
+
+Example using ``AugmentationSequential`` with synchronized transforms::
+
+    import torch
+    import kornia.augmentation as K
+
+    img = torch.rand(1, 3, 256, 256)
+    mask = torch.rand(1, 1, 256, 256)
+
+    aug = K.AugmentationSequential(
+        K.RandomResizedCrop((128, 128), p=1.0),
+        data_keys=["input", "mask"],
+    )
+
+    img_out, mask_out = aug(img, mask)
+    # identical random parameters applied to both tensors
+
+The core distinction: ``AugmentationSequential`` guarantees that random
+augmentation parameters are shared across all specified data keys, maintaining
+geometric consistency. ``ImageSequential`` applies operations independently to
+single image tensors without multi-target awareness.
+
 
 PatchSequential
 ---------------

--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -48,7 +48,6 @@ from . import (
 )
 
 
-
 # Multi-framework support using ivy
 from .transpiler import to_jax, to_numpy, to_tensorflow
 

--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -15,6 +15,13 @@
 # limitations under the License.
 #
 
+"""
+Kornia — Differentiable computer vision and image processing for PyTorch.
+
+This package exposes core modules (filters, geometry, etc.) and provides
+convenience imports at the top level.
+"""
+
 # NOTE: kornia filters and geometry must go first since are the core of the library
 # and by changing the import order you might get into a circular dependencies issue.
 from . import filters
@@ -40,6 +47,8 @@ from . import (
     utils,
     x,
 )
+
+
 
 # Multi-framework support using ivy
 from .transpiler import to_jax, to_numpy, to_tensorflow

--- a/kornia/__init__.py
+++ b/kornia/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia — Differentiable computer vision and image processing for PyTorch.
+"""Kornia — Differentiable computer vision and image processing for PyTorch.
 
 This package exposes core modules (filters, geometry, etc.) and provides
 convenience imports at the top level.

--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Augmentation — Differentiable image, video, and 3D data augmentation for PyTorch.
+
+This subpackage provides a wide range of augmentation modules for computer vision tasks.
+"""
+
 # Lazy loading auto module
 from kornia.augmentation import auto, container
 from kornia.augmentation._2d import (

--- a/kornia/augmentation/__init__.py
+++ b/kornia/augmentation/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Augmentation — Differentiable image, video, and 3D data augmentation for PyTorch.
+"""Kornia Augmentation — Differentiable image, video, and 3D data augmentation for PyTorch.
 
 This subpackage provides a wide range of augmentation modules for computer vision tasks.
 """

--- a/kornia/augmentation/auto/__init__.py
+++ b/kornia/augmentation/auto/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Augmentation Auto — Automated augmentation policies for computer vision.
+
+This subpackage provides AutoAugment and related policy-based augmentation utilities.
+"""
+
 from .autoaugment import AutoAugment
 from .base import PolicyAugmentBase
 from .operations import PolicySequential

--- a/kornia/augmentation/auto/__init__.py
+++ b/kornia/augmentation/auto/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Augmentation Auto — Automated augmentation policies for computer vision.
+"""Kornia Augmentation Auto — Automated augmentation policies for computer vision.
 
 This subpackage provides AutoAugment and related policy-based augmentation utilities.
 """

--- a/kornia/augmentation/auto/autoaugment/__init__.py
+++ b/kornia/augmentation/auto/autoaugment/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia AutoAugment — AutoAugment policy implementations for Kornia augmentation.
+"""Kornia AutoAugment — AutoAugment policy implementations for Kornia augmentation.
 
 This subpackage provides the AutoAugment class and related utilities.
 """

--- a/kornia/augmentation/auto/autoaugment/__init__.py
+++ b/kornia/augmentation/auto/autoaugment/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia AutoAugment — AutoAugment policy implementations for Kornia augmentation.
+
+This subpackage provides the AutoAugment class and related utilities.
+"""
+
 from .autoaugment import AutoAugment

--- a/kornia/augmentation/auto/operations/__init__.py
+++ b/kornia/augmentation/auto/operations/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia AutoAugment Operations — Building blocks for policy-based augmentation.
+"""Kornia AutoAugment Operations — Building blocks for policy-based augmentation.
 
 This subpackage provides operation classes and utilities for AutoAugment policies.
 """

--- a/kornia/augmentation/auto/operations/__init__.py
+++ b/kornia/augmentation/auto/operations/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia AutoAugment Operations — Building blocks for policy-based augmentation.
+
+This subpackage provides operation classes and utilities for AutoAugment policies.
+"""
+
 from .base import OperationBase
 from .ops import *
 from .policy import PolicySequential

--- a/kornia/augmentation/auto/rand_augment/__init__.py
+++ b/kornia/augmentation/auto/rand_augment/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia RandAugment — RandAugment policy implementations for Kornia augmentation.
+"""Kornia RandAugment — RandAugment policy implementations for Kornia augmentation.
 
 This subpackage provides the RandAugment class and related utilities.
 """

--- a/kornia/augmentation/auto/rand_augment/__init__.py
+++ b/kornia/augmentation/auto/rand_augment/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia RandAugment — RandAugment policy implementations for Kornia augmentation.
+
+This subpackage provides the RandAugment class and related utilities.
+"""
+
 from .rand_augment import RandAugment

--- a/kornia/augmentation/auto/trivial_augment/__init__.py
+++ b/kornia/augmentation/auto/trivial_augment/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia TrivialAugment — TrivialAugment policy implementations for Kornia augmentation.
+
+This subpackage provides the TrivialAugment class and related utilities.
+"""
+
 from .trivial_augment import TrivialAugment

--- a/kornia/augmentation/auto/trivial_augment/__init__.py
+++ b/kornia/augmentation/auto/trivial_augment/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia TrivialAugment — TrivialAugment policy implementations for Kornia augmentation.
+"""Kornia TrivialAugment — TrivialAugment policy implementations for Kornia augmentation.
 
 This subpackage provides the TrivialAugment class and related utilities.
 """

--- a/kornia/augmentation/container/__init__.py
+++ b/kornia/augmentation/container/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Augmentation Container — Sequential and dispatcher augmentation utilities.
+
+This subpackage provides augmentation containers and dispatchers for flexible pipelines.
+"""
+
 from kornia.augmentation.container.augment import AugmentationSequential
 from kornia.augmentation.container.base import ImageSequentialBase
 from kornia.augmentation.container.dispatcher import ManyToManyAugmentationDispather, ManyToOneAugmentationDispather

--- a/kornia/augmentation/container/__init__.py
+++ b/kornia/augmentation/container/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Augmentation Container — Sequential and dispatcher augmentation utilities.
+"""Kornia Augmentation Container — Sequential and dispatcher augmentation utilities.
 
 This subpackage provides augmentation containers and dispatchers for flexible pipelines.
 """

--- a/kornia/augmentation/presets/__init__.py
+++ b/kornia/augmentation/presets/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Augmentation Presets — Predefined augmentation pipelines and configurations.
+"""Kornia Augmentation Presets — Predefined augmentation pipelines and configurations.
 
 This subpackage provides ready-to-use augmentation presets for common tasks.
 """

--- a/kornia/augmentation/presets/__init__.py
+++ b/kornia/augmentation/presets/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+Kornia Augmentation Presets — Predefined augmentation pipelines and configurations.
+
+This subpackage provides ready-to-use augmentation presets for common tasks.
+"""

--- a/kornia/augmentation/presets/ada.py
+++ b/kornia/augmentation/presets/ada.py
@@ -178,7 +178,7 @@ class AdaptiveDiscriminatorAugmentation(AugmentationSequential):
         )
 
     def update(self, real_acc: float) -> None:
-        r"""Updates internal params `p` once every `update_every` calls based on discriminator accuracy.
+        r"""Update internal params `p` once every `update_every` calls based on discriminator accuracy.
 
         the update is based on an exponential moving average of `real_acc`
         `p` is updated by adding or subtracting `adjustment_speed` from it and clamp it at [0, `max_p`]

--- a/kornia/augmentation/random_generator/__init__.py
+++ b/kornia/augmentation/random_generator/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Augmentation Random Generator — Random parameter generators for augmentations.
+
+This subpackage provides random generators for 2D and 3D augmentation modules.
+"""
+
 from kornia.augmentation.random_generator._2d import *
 from kornia.augmentation.random_generator._3d import *
 

--- a/kornia/augmentation/random_generator/__init__.py
+++ b/kornia/augmentation/random_generator/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Augmentation Random Generator — Random parameter generators for augmentations.
+"""Kornia Augmentation Random Generator — Random parameter generators for augmentations.
 
 This subpackage provides random generators for 2D and 3D augmentation modules.
 """

--- a/kornia/augmentation/utils/__init__.py
+++ b/kornia/augmentation/utils/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Augmentation Utils — Helper functions and utilities for augmentations.
+"""Kornia Augmentation Utils — Helper functions and utilities for augmentations.
 
 This subpackage provides internal helpers and utility functions for augmentation modules.
 """

--- a/kornia/augmentation/utils/__init__.py
+++ b/kornia/augmentation/utils/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Augmentation Utils — Helper functions and utilities for augmentations.
+
+This subpackage provides internal helpers and utility functions for augmentation modules.
+"""
+
 from kornia.augmentation.utils.helpers import (
     _adapted_beta,
     _adapted_rsampling,

--- a/kornia/color/__init__.py
+++ b/kornia/color/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Color — Color space conversions and color-related utilities for PyTorch.
+"""Kornia Color — Color space conversions and color-related utilities for PyTorch.
 
 This subpackage provides modules for color transformations, colormaps, and conversions.
 """

--- a/kornia/color/__init__.py
+++ b/kornia/color/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Color — Color space conversions and color-related utilities for PyTorch.
+
+This subpackage provides modules for color transformations, colormaps, and conversions.
+"""
+
 from .colormap import AUTUMN, ApplyColorMap, ColorMap, ColorMapType, RGBColor, apply_colormap
 from .gray import BgrToGrayscale, GrayscaleToRgb, RgbToGrayscale, bgr_to_grayscale, grayscale_to_rgb, rgb_to_grayscale
 from .hls import HlsToRgb, RgbToHls, hls_to_rgb, rgb_to_hls

--- a/kornia/contrib/__init__.py
+++ b/kornia/contrib/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Contrib — Experimental and contributed modules for Kornia.
+
+This subpackage provides community-contributed and experimental features.
+"""
+
 from .classification import ClassificationHead
 from .connected_components import connected_components
 from .diamond_square import diamond_square

--- a/kornia/contrib/__init__.py
+++ b/kornia/contrib/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib — Experimental and contributed modules for Kornia.
+"""Kornia Contrib — Experimental and contributed modules for Kornia.
 
 This subpackage provides community-contributed and experimental features.
 """

--- a/kornia/contrib/models/__init__.py
+++ b/kornia/contrib/models/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia Contrib Models — Experimental and contributed model structures for Kornia.
+
+This subpackage provides contributed model classes and result structures.
+"""
+
 from kornia.contrib.models.structures import Prompts, SegmentationResults

--- a/kornia/contrib/models/__init__.py
+++ b/kornia/contrib/models/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib Models — Experimental and contributed model structures for Kornia.
+"""Kornia Contrib Models — Experimental and contributed model structures for Kornia.
 
 This subpackage provides contributed model classes and result structures.
 """

--- a/kornia/contrib/models/efficient_vit/__init__.py
+++ b/kornia/contrib/models/efficient_vit/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Contrib EfficientViT — Efficient Vision Transformer models for Kornia.
+
+This subpackage provides EfficientViT model classes and configurations.
+"""
+
 from .model import EfficientViT, EfficientViTConfig
 
 __all__ = ["EfficientViT", "EfficientViTConfig"]

--- a/kornia/contrib/models/efficient_vit/__init__.py
+++ b/kornia/contrib/models/efficient_vit/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib EfficientViT — Efficient Vision Transformer models for Kornia.
+"""Kornia Contrib EfficientViT — Efficient Vision Transformer models for Kornia.
 
 This subpackage provides EfficientViT model classes and configurations.
 """

--- a/kornia/contrib/models/efficient_vit/nn/__init__.py
+++ b/kornia/contrib/models/efficient_vit/nn/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+Kornia Contrib EfficientViT NN — Neural network layers for EfficientViT models.
+
+This subpackage provides neural network building blocks for EfficientViT.
+"""

--- a/kornia/contrib/models/efficient_vit/nn/__init__.py
+++ b/kornia/contrib/models/efficient_vit/nn/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib EfficientViT NN — Neural network layers for EfficientViT models.
+"""Kornia Contrib EfficientViT NN — Neural network layers for EfficientViT models.
 
 This subpackage provides neural network building blocks for EfficientViT.
 """

--- a/kornia/contrib/models/efficient_vit/utils/__init__.py
+++ b/kornia/contrib/models/efficient_vit/utils/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Contrib EfficientViT Utils — Utility functions for EfficientViT models.
+
+This subpackage provides helper functions and utilities for EfficientViT implementations.
+"""
+
 # EfficientViT: Multi-Scale Linear Attention for High-Resolution Dense Prediction
 # Han Cai, Junyan Li, Muyan Hu, Chuang Gan, Song Han
 # International Conference on Computer Vision (ICCV), 2023

--- a/kornia/contrib/models/efficient_vit/utils/__init__.py
+++ b/kornia/contrib/models/efficient_vit/utils/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib EfficientViT Utils — Utility functions for EfficientViT models.
+"""Kornia Contrib EfficientViT Utils — Utility functions for EfficientViT models.
 
 This subpackage provides helper functions and utilities for EfficientViT implementations.
 """

--- a/kornia/contrib/models/rt_detr/__init__.py
+++ b/kornia/contrib/models/rt_detr/__init__.py
@@ -15,5 +15,11 @@
 # limitations under the License.
 #
 
+"""
+Kornia Contrib RT-DETR — Real-time DEtection TRansformer models for Kornia.
+
+This subpackage provides RT-DETR model classes, configs, and post-processors.
+"""
+
 from kornia.contrib.models.rt_detr.model import RTDETR, RTDETRConfig, RTDETRModelType
 from kornia.contrib.models.rt_detr.post_processor import DETRPostProcessor

--- a/kornia/contrib/models/rt_detr/__init__.py
+++ b/kornia/contrib/models/rt_detr/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib RT-DETR — Real-time DEtection TRansformer models for Kornia.
+"""Kornia Contrib RT-DETR — Real-time DEtection TRansformer models for Kornia.
 
 This subpackage provides RT-DETR model classes, configs, and post-processors.
 """

--- a/kornia/contrib/models/rt_detr/architecture/__init__.py
+++ b/kornia/contrib/models/rt_detr/architecture/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib RT-DETR Architecture — Model architecture components for RT-DETR.
+"""Kornia Contrib RT-DETR Architecture — Model architecture components for RT-DETR.
 
 This subpackage provides building blocks for RT-DETR model architectures.
 """

--- a/kornia/contrib/models/rt_detr/architecture/__init__.py
+++ b/kornia/contrib/models/rt_detr/architecture/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+Kornia Contrib RT-DETR Architecture — Model architecture components for RT-DETR.
+
+This subpackage provides building blocks for RT-DETR model architectures.
+"""

--- a/kornia/contrib/models/sam/__init__.py
+++ b/kornia/contrib/models/sam/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib SAM — Segment Anything Model (SAM) integration for Kornia.
+"""Kornia Contrib SAM — Segment Anything Model (SAM) integration for Kornia.
 
 This subpackage provides SAM model classes and configuration for segmentation tasks.
 """

--- a/kornia/contrib/models/sam/__init__.py
+++ b/kornia/contrib/models/sam/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia Contrib SAM — Segment Anything Model (SAM) integration for Kornia.
+
+This subpackage provides SAM model classes and configuration for segmentation tasks.
+"""
+
 from kornia.contrib.models.sam.model import Sam, SamConfig, SamModelType

--- a/kornia/contrib/models/sam/architecture/__init__.py
+++ b/kornia/contrib/models/sam/architecture/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Contrib SAM Architecture — Model architecture components for SAM.
+"""Kornia Contrib SAM Architecture — Model architecture components for SAM.
 
 This subpackage provides building blocks for the Segment Anything Model (SAM).
 """

--- a/kornia/contrib/models/sam/architecture/__init__.py
+++ b/kornia/contrib/models/sam/architecture/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+Kornia Contrib SAM Architecture — Model architecture components for SAM.
+
+This subpackage provides building blocks for the Segment Anything Model (SAM).
+"""

--- a/kornia/core/__init__.py
+++ b/kornia/core/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Core — Core tensor operations, backends, and utilities for Kornia.
+"""Kornia Core — Core tensor operations, backends, and utilities for Kornia.
 
 This subpackage provides core functionality, device management, and backend support.
 """

--- a/kornia/core/__init__.py
+++ b/kornia/core/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Core — Core tensor operations, backends, and utilities for Kornia.
+
+This subpackage provides core functionality, device management, and backend support.
+"""
+
 from . import external
 from ._backend import (
     Device,

--- a/kornia/core/check.py
+++ b/kornia/core/check.py
@@ -127,7 +127,7 @@ def KORNIA_CHECK(condition: bool, msg: Optional[str] = None, raises: bool = True
 
 
 def KORNIA_UNWRAP(maybe_obj: object, typ: Any) -> Any:
-    """Unwraps an optional contained value that may or not be present.
+    """Unwrap an optional contained value that may or not be present.
 
     Args:
         maybe_obj: the object to unwrap.
@@ -461,7 +461,7 @@ def KORNIA_CHECK_LAF(laf: Tensor, raises: bool = True) -> bool:
 
 
 def _handle_invalid_range(msg: Optional[str], raises: bool, min_val: float | Tensor, max_val: float | Tensor) -> bool:
-    """Helper function to handle invalid range cases."""
+    """Handle invalid range cases."""
     err_msg = f"Invalid image value range. Expect [0, 1] but got [{min_val}, {max_val}]."
     if msg is not None:
         err_msg += f"\n{msg}"

--- a/kornia/core/mixin/__init__.py
+++ b/kornia/core/mixin/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Core Mixin — Mixins for image modules and ONNX export in Kornia.
+"""Kornia Core Mixin — Mixins for image modules and ONNX export in Kornia.
 
 This subpackage provides mixin classes for extending core functionality.
 """

--- a/kornia/core/mixin/__init__.py
+++ b/kornia/core/mixin/__init__.py
@@ -15,5 +15,11 @@
 # limitations under the License.
 #
 
+"""
+Kornia Core Mixin — Mixins for image modules and ONNX export in Kornia.
+
+This subpackage provides mixin classes for extending core functionality.
+"""
+
 from .image_module import ImageModuleMixIn
 from .onnx import ONNXExportMixin, ONNXMixin, ONNXRuntimeMixin

--- a/kornia/enhance/__init__.py
+++ b/kornia/enhance/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Enhance — Image enhancement operations for Kornia.
+
+This subpackage provides modules for brightness, contrast, and other image enhancements.
+"""
+
 from .adjust import (
     AdjustBrightness,
     AdjustBrightnessAccumulative,

--- a/kornia/enhance/__init__.py
+++ b/kornia/enhance/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Enhance — Image enhancement operations for Kornia.
+"""Kornia Enhance — Image enhancement operations for Kornia.
 
 This subpackage provides modules for brightness, contrast, and other image enhancements.
 """

--- a/kornia/feature/__init__.py
+++ b/kornia/feature/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature — Feature detection, description, and matching for Kornia.
+
+This subpackage provides modules for keypoint detection, descriptors, and feature matching.
+"""
+
 from .affine_shape import LAFAffineShapeEstimator, LAFAffNetShapeEstimator, PatchAffineShapeEstimator
 from .dedode import DeDoDe
 from .defmo import DeFMO

--- a/kornia/feature/__init__.py
+++ b/kornia/feature/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature — Feature detection, description, and matching for Kornia.
+"""Kornia Feature — Feature detection, description, and matching for Kornia.
 
 This subpackage provides modules for keypoint detection, descriptors, and feature matching.
 """

--- a/kornia/feature/adalam/__init__.py
+++ b/kornia/feature/adalam/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature Adalam — AdaLAM feature matching for Kornia.
+
+This subpackage provides AdaLAM filtering and matching utilities.
+"""
+
 from .adalam import AdalamFilter, get_adalam_default_config, match_adalam

--- a/kornia/feature/adalam/__init__.py
+++ b/kornia/feature/adalam/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature Adalam — AdaLAM feature matching for Kornia.
+"""Kornia Feature Adalam — AdaLAM feature matching for Kornia.
 
 This subpackage provides AdaLAM filtering and matching utilities.
 """

--- a/kornia/feature/adalam/utils.py
+++ b/kornia/feature/adalam/utils.py
@@ -77,7 +77,7 @@ def piecewise_arange(piecewise_idxer: Tensor) -> Tensor:
 
 
 def batch_2x2_inv(m: Tensor, check_dets: bool = False) -> Tensor:
-    """Returns inverse of batch of 2x2 matrices."""
+    """Return inverse of batch of 2x2 matrices."""
     a = m[..., 0, 0]
     b = m[..., 0, 1]
     c = m[..., 1, 0]
@@ -94,17 +94,17 @@ def batch_2x2_inv(m: Tensor, check_dets: bool = False) -> Tensor:
 
 
 def batch_2x2_Q(m: Tensor) -> Tensor:
-    """Returns Q of batch of 2x2 matrices."""
+    """Return Q of batch of 2x2 matrices."""
     return batch_2x2_inv(batch_2x2_invQ(m), check_dets=True)
 
 
 def batch_2x2_invQ(m: Tensor) -> Tensor:
-    """Returns inverse Q of batch of 2x2 matrices."""
+    """Return inverse Q of batch of 2x2 matrices."""
     return m @ m.transpose(-1, -2)
 
 
 def batch_2x2_det(m: Tensor) -> Tensor:
-    """Returns determinant of batch of 2x2 matrices."""
+    """Return determinant of batch of 2x2 matrices."""
     a = m[..., 0, 0]
     b = m[..., 0, 1]
     c = m[..., 1, 0]
@@ -113,7 +113,7 @@ def batch_2x2_det(m: Tensor) -> Tensor:
 
 
 def batch_2x2_ellipse(m: Tensor, *, eps: float = 0.0) -> Tuple[Tensor, Tensor]:
-    """Returns Eigenvalues and Eigenvectors of batch of 2x2 matrices."""
+    """Return Eigenvalues and Eigenvectors of batch of 2x2 matrices."""
     am = m[..., 0, 0]
     bm = m[..., 0, 1]
     cm = m[..., 1, 0]
@@ -150,7 +150,7 @@ def batch_2x2_ellipse(m: Tensor, *, eps: float = 0.0) -> Tuple[Tensor, Tensor]:
 
 
 def draw_first_k_couples(k: int, rdims: Tensor, dv: torch.device) -> Tensor:
-    """Returns first k couples.
+    """Return first k couples.
 
     Exhaustive search over the first n samples:
      * n(n+1)/2 = n2/2 + n/2 couples

--- a/kornia/feature/dedode/__init__.py
+++ b/kornia/feature/dedode/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature DeDoDe — DeDoDe feature detector for Kornia.
+
+This subpackage provides the DeDoDe keypoint detector and related utilities.
+"""
+
 from .dedode import DeDoDe
 
 __all__ = ["DeDoDe"]

--- a/kornia/feature/dedode/__init__.py
+++ b/kornia/feature/dedode/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature DeDoDe — DeDoDe feature detector for Kornia.
+"""Kornia Feature DeDoDe — DeDoDe feature detector for Kornia.
 
 This subpackage provides the DeDoDe keypoint detector and related utilities.
 """

--- a/kornia/feature/dedode/transformer/__init__.py
+++ b/kornia/feature/dedode/transformer/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature DeDoDe Transformer — Transformer backbones for DeDoDe feature detector.
+"""Kornia Feature DeDoDe Transformer — Transformer backbones for DeDoDe feature detector.
 
 This subpackage provides transformer models for DeDoDe feature extraction.
 """

--- a/kornia/feature/dedode/transformer/__init__.py
+++ b/kornia/feature/dedode/transformer/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature DeDoDe Transformer — Transformer backbones for DeDoDe feature detector.
+
+This subpackage provides transformer models for DeDoDe feature extraction.
+"""
+
 from .dinov2 import vit_large
 
 __all__ = [

--- a/kornia/feature/dedode/transformer/layers/__init__.py
+++ b/kornia/feature/dedode/transformer/layers/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""Layers submodule for Kornia DeDoDe transformer.
+
+This package provides transformer layer components such as attention, blocks, MLPs, patch embedding,
+and SwiGLU FFN for DeDoDe feature extraction.
+"""
+
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 # All rights reserved.
 #

--- a/kornia/feature/disk/__init__.py
+++ b/kornia/feature/disk/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature DISK — DISK feature detector and descriptor for Kornia.
+"""Kornia Feature DISK — DISK feature detector and descriptor for Kornia.
 
 This subpackage provides the DISK keypoint detector and feature structures.
 """

--- a/kornia/feature/disk/__init__.py
+++ b/kornia/feature/disk/__init__.py
@@ -15,5 +15,11 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature DISK — DISK feature detector and descriptor for Kornia.
+
+This subpackage provides the DISK keypoint detector and feature structures.
+"""
+
 from .disk import DISK
 from .structs import DISKFeatures

--- a/kornia/feature/lightglue_onnx/__init__.py
+++ b/kornia/feature/lightglue_onnx/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature LightGlue ONNX — ONNX-based LightGlue feature matcher for Kornia.
+"""Kornia Feature LightGlue ONNX — ONNX-based LightGlue feature matcher for Kornia.
 
 This subpackage provides the OnnxLightGlue matcher and related utilities.
 """

--- a/kornia/feature/lightglue_onnx/__init__.py
+++ b/kornia/feature/lightglue_onnx/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature LightGlue ONNX — ONNX-based LightGlue feature matcher for Kornia.
+
+This subpackage provides the OnnxLightGlue matcher and related utilities.
+"""
+
 from .lightglue import OnnxLightGlue

--- a/kornia/feature/lightglue_onnx/utils/__init__.py
+++ b/kornia/feature/lightglue_onnx/utils/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature LightGlue ONNX Utils — Utilities for ONNX-based LightGlue matcher.
+"""Kornia Feature LightGlue ONNX Utils — Utilities for ONNX-based LightGlue matcher.
 
 This subpackage provides helper functions for LightGlue ONNX models.
 """

--- a/kornia/feature/lightglue_onnx/utils/__init__.py
+++ b/kornia/feature/lightglue_onnx/utils/__init__.py
@@ -15,5 +15,11 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature LightGlue ONNX Utils — Utilities for ONNX-based LightGlue matcher.
+
+This subpackage provides helper functions for LightGlue ONNX models.
+"""
+
 from .download import download_onnx_from_url
 from .keypoints import normalize_keypoints

--- a/kornia/feature/loftr/__init__.py
+++ b/kornia/feature/loftr/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature LoFTR — LoFTR feature matcher for Kornia.
+"""Kornia Feature LoFTR — LoFTR feature matcher for Kornia.
 
 This subpackage provides the LoFTR (Detector-Free Local Feature Matching) implementation.
 """

--- a/kornia/feature/loftr/__init__.py
+++ b/kornia/feature/loftr/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature LoFTR — LoFTR feature matcher for Kornia.
+
+This subpackage provides the LoFTR (Detector-Free Local Feature Matching) implementation.
+"""
+
 from __future__ import annotations
 
 from .loftr import LoFTR

--- a/kornia/feature/loftr/backbone/__init__.py
+++ b/kornia/feature/loftr/backbone/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature LoFTR Backbone — Backbone modules for LoFTR feature matcher.
+
+This subpackage provides backbone architectures for LoFTR feature extraction.
+"""
+
 from __future__ import annotations
 
 from typing import Any

--- a/kornia/feature/loftr/backbone/__init__.py
+++ b/kornia/feature/loftr/backbone/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature LoFTR Backbone — Backbone modules for LoFTR feature matcher.
+"""Kornia Feature LoFTR Backbone — Backbone modules for LoFTR feature matcher.
 
 This subpackage provides backbone architectures for LoFTR feature extraction.
 """

--- a/kornia/feature/loftr/loftr_module/__init__.py
+++ b/kornia/feature/loftr/loftr_module/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature LoFTR Module — LoFTR module components for Kornia.
+"""Kornia Feature LoFTR Module — LoFTR module components for Kornia.
 
 This subpackage provides fine preprocessing and transformer modules for LoFTR.
 """

--- a/kornia/feature/loftr/loftr_module/__init__.py
+++ b/kornia/feature/loftr/loftr_module/__init__.py
@@ -15,5 +15,11 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature LoFTR Module — LoFTR module components for Kornia.
+
+This subpackage provides fine preprocessing and transformer modules for LoFTR.
+"""
+
 from .fine_preprocess import FinePreprocess
 from .transformer import LocalFeatureTransformer

--- a/kornia/feature/loftr/utils/__init__.py
+++ b/kornia/feature/loftr/utils/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature LoFTR Utils — Utilities for LoFTR feature matcher.
+"""Kornia Feature LoFTR Utils — Utilities for LoFTR feature matcher.
 
 This subpackage provides helper functions for LoFTR modules.
 """

--- a/kornia/feature/loftr/utils/__init__.py
+++ b/kornia/feature/loftr/utils/__init__.py
@@ -14,3 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+Kornia Feature LoFTR Utils — Utilities for LoFTR feature matcher.
+
+This subpackage provides helper functions for LoFTR modules.
+"""

--- a/kornia/feature/orientation.py
+++ b/kornia/feature/orientation.py
@@ -190,7 +190,7 @@ class OriNet(nn.Module):
 
     @staticmethod
     def _normalize_input(x: torch.Tensor, eps: float = 1e-6) -> torch.Tensor:
-        """Utility function that normalizes the input by batch."""
+        """Normalize the input by batch."""
         sp, mp = torch.std_mean(x, dim=(-3, -2, -1), keepdim=True)
         # WARNING: we need to .detach() input, otherwise the gradients produced by
         # the patches extractor with F.grid_sample are very noisy, making the detector

--- a/kornia/feature/sold2/__init__.py
+++ b/kornia/feature/sold2/__init__.py
@@ -15,5 +15,11 @@
 # limitations under the License.
 #
 
+"""
+Kornia Feature SOLD2 — SOLD2 line segment detector for Kornia.
+
+This subpackage provides the SOLD2 detector and related utilities.
+"""
+
 from .sold2 import SOLD2
 from .sold2_detector import SOLD2_detector

--- a/kornia/feature/sold2/__init__.py
+++ b/kornia/feature/sold2/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Feature SOLD2 — SOLD2 line segment detector for Kornia.
+"""Kornia Feature SOLD2 — SOLD2 line segment detector for Kornia.
 
 This subpackage provides the SOLD2 detector and related utilities.
 """

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Filters — Image filtering operations for Kornia.
+
+This subpackage provides modules for blurring, sharpening, and other image filters.
+"""
+
 from __future__ import annotations
 
 from .bilateral import BilateralBlur, JointBilateralBlur, bilateral_blur, joint_bilateral_blur

--- a/kornia/filters/__init__.py
+++ b/kornia/filters/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Filters — Image filtering operations for Kornia.
+"""Kornia Filters — Image filtering operations for Kornia.
 
 This subpackage provides modules for blurring, sharpening, and other image filters.
 """

--- a/kornia/filters/dissolving.py
+++ b/kornia/filters/dissolving.py
@@ -105,7 +105,7 @@ class StableDiffusionDissolving(ImageModule):
 
     Based on :cite:`shi2024dissolving`, the dissolving transformation is essentially applying one-step
     reverse diffusion. Our implementation currently supports HuggingFace implementations of SD 1.4, 1.5
-    and 2.1. SD 1.X tends to remove more details than SD2.1.
+    and SD-XL (replacing the discontinued SD 2.1). SD 1.X tends to remove more details than SD-XL.
 
     .. list-table:: Title
         :widths: 32 32 32
@@ -113,13 +113,13 @@ class StableDiffusionDissolving(ImageModule):
 
         * - SD 1.4
           - SD 1.5
-          - SD 2.1
+          - SD-XL
         * - figure:: https://raw.githubusercontent.com/kornia/data/main/dslv-sd-1.4.png
           - figure:: https://raw.githubusercontent.com/kornia/data/main/dslv-sd-1.5.png
           - figure:: https://raw.githubusercontent.com/kornia/data/main/dslv-sd-2.1.png
 
     Args:
-        version: the version of the stable diffusion model.
+        version: the version of the stable diffusion model. Options: "1.4", "1.5", "xl".
         **kwargs: additional arguments for `.from_pretrained`.
 
     """
@@ -150,9 +150,9 @@ class StableDiffusionDissolving(ImageModule):
             self._sdm_model = StableDiffusionPipeline.from_pretrained(  # type:ignore
                 "runwayml/stable-diffusion-v1-5", scheduler=scheduler, **kwargs
             )
-        elif version == "2.1":
+        elif version == "xl":
             self._sdm_model = StableDiffusionPipeline.from_pretrained(  # type:ignore
-                "stabilityai/stable-diffusion-2-1", scheduler=scheduler, **kwargs
+                "stabilityai/stable-diffusion-xl-base-1.0", scheduler=scheduler, **kwargs
             )
         else:
             raise NotImplementedError

--- a/kornia/geometry/__init__.py
+++ b/kornia/geometry/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry — Geometric vision operations for Kornia.
+"""Kornia Geometry — Geometric vision operations for Kornia.
 
 This subpackage provides modules for transformations, camera models, and geometry processing.
 """

--- a/kornia/geometry/__init__.py
+++ b/kornia/geometry/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry — Geometric vision operations for Kornia.
+
+This subpackage provides modules for transformations, camera models, and geometry processing.
+"""
+
 from .bbox import *
 from .calibration import *
 from .camera import *

--- a/kornia/geometry/calibration/__init__.py
+++ b/kornia/geometry/calibration/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Calibration — Camera calibration utilities for Kornia.
+"""Kornia Geometry Calibration — Camera calibration utilities for Kornia.
 
 This subpackage provides functions for camera calibration, distortion, and undistortion.
 """

--- a/kornia/geometry/calibration/__init__.py
+++ b/kornia/geometry/calibration/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Calibration — Camera calibration utilities for Kornia.
+
+This subpackage provides functions for camera calibration, distortion, and undistortion.
+"""
+
 from .distort import distort_points, tilt_projection
 from .pnp import solve_pnp_dlt
 from .undistort import undistort_image, undistort_points

--- a/kornia/geometry/camera/__init__.py
+++ b/kornia/geometry/camera/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Camera — Camera models and camera-related utilities for Kornia.
+
+This subpackage provides camera models, distortion, and projection functions.
+"""
+
 from .distortion_affine import distort_points_affine, dx_distort_points_affine, undistort_points_affine
 from .distortion_kannala_brandt import (
     distort_points_kannala_brandt,

--- a/kornia/geometry/camera/__init__.py
+++ b/kornia/geometry/camera/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Camera — Camera models and camera-related utilities for Kornia.
+"""Kornia Geometry Camera — Camera models and camera-related utilities for Kornia.
 
 This subpackage provides camera models, distortion, and projection functions.
 """

--- a/kornia/geometry/camera/utils.py
+++ b/kornia/geometry/camera/utils.py
@@ -1,0 +1,245 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch import Tensor
+
+from kornia.core import Device
+from kornia.geometry.camera import PinholeCamera
+
+
+def create_camera_dimensions(
+    device: Device, dtype: torch.dtype, n_cams1: int = 3, n_cams2: int = 2
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Create camera dimensions for ray sampling.
+
+    Args:
+        device: Device for tensors
+        dtype: Data type for tensors
+        n_cams1: Number of cameras in first group (default: 3)
+        n_cams2: Number of cameras in second group (default: 2)
+
+    Returns:
+        Tuple of (heights, widths, num_img_rays) tensors
+    """
+    heights: torch.Tensor = torch.cat(
+        (
+            torch.tensor([200] * n_cams1, device=device, dtype=dtype),
+            torch.tensor([100] * n_cams2, device=device, dtype=dtype),
+        )
+    )
+    widths: torch.Tensor = torch.cat(
+        (
+            torch.tensor([300] * n_cams1, device=device, dtype=dtype),
+            torch.tensor([400] * n_cams2, device=device, dtype=dtype),
+        )
+    )
+    num_img_rays: torch.Tensor = torch.cat(
+        (
+            torch.tensor([10] * n_cams1, device=device, dtype=dtype),
+            torch.tensor([15] * n_cams2, device=device, dtype=dtype),
+        )
+    )
+    return heights, widths, num_img_rays
+
+
+def create_intrinsics(
+    fxs: list[float | int],
+    fys: list[float | int],
+    cxs: Tensor | list[float | int],
+    cys: Tensor | list[float | int],
+    device: Device,
+    dtype: torch.dtype,
+) -> Tensor:
+    """Create intrinsic camera matrices from focal lengths and principal points.
+
+    Args:
+        fxs: Focal length in x direction
+        fys: Focal length in y direction
+        cxs: Principal point x coordinate
+        cys: Principal point y coordinate
+        device: Device for tensors
+        dtype: Data type for tensors
+
+    Returns:
+        Stacked intrinsic matrices of shape (N, 4, 4)
+    """
+    intrinsics_batch: list[Tensor] = []
+    # Convert cxs and cys to lists if they are tensors
+    cxs_list = cxs.tolist() if isinstance(cxs, Tensor) else cxs
+    cys_list = cys.tolist() if isinstance(cys, Tensor) else cys
+    for fx, fy, cx, cy in zip(fxs, fys, cxs_list, cys_list):
+        intrinsics = torch.eye(4, device=device, dtype=dtype)
+        intrinsics[0, 0] = fx
+        intrinsics[1, 1] = fy
+        intrinsics[0, 2] = cx
+        intrinsics[1, 2] = cy
+        intrinsics_batch.append(intrinsics)
+    return torch.stack(intrinsics_batch)
+
+
+def create_extrinsics_with_rotation(
+    alphas: list[float],
+    betas: list[float],
+    gammas: list[float],
+    txs: list[float],
+    tys: list[float],
+    tzs: list[float],
+    device: Device,
+    dtype: torch.dtype,
+) -> Tensor:
+    """Create extrinsic camera matrices with rotation and translation.
+
+    Args:
+        alphas: Rotation angles around x-axis
+        betas: Rotation angles around y-axis
+        gammas: Rotation angles around z-axis
+        txs: Translation in x direction
+        tys: Translation in y direction
+        tzs: Translation in z direction
+        device: Device for tensors
+        dtype: Data type for tensors
+
+    Returns:
+        Stacked extrinsic matrices of shape (N, 4, 4)
+    """
+    extrinsics_batch: list[Tensor] = []
+    for alpha, beta, gamma, tx, ty, tz in zip(alphas, betas, gammas, txs, tys, tzs):
+        Rx = torch.eye(3, device=device, dtype=dtype)
+        Rx[1, 1] = math.cos(alpha)
+        Rx[1, 2] = math.sin(alpha)
+        Rx[2, 1] = -Rx[1, 2]
+        Rx[2, 2] = Rx[1, 1]
+
+        Ry = torch.eye(3, device=device, dtype=dtype)
+        Ry[0, 0] = math.cos(beta)
+        Ry[0, 2] = -math.sin(beta)
+        Ry[2, 0] = -Ry[0, 2]
+        Ry[2, 2] = Ry[0, 0]
+
+        Rz = torch.eye(3, device=device, dtype=dtype)
+        Rz[0, 0] = math.cos(gamma)
+        Rz[0, 1] = math.sin(gamma)
+        Rz[1, 0] = -Rz[0, 1]
+        Rz[1, 1] = Rz[0, 0]
+
+        Ryz = torch.matmul(Ry, Rz)
+        R = torch.matmul(Rx, Ryz)
+
+        extrinsics = torch.eye(4, device=device, dtype=dtype)
+        extrinsics[..., 0, -1] = tx
+        extrinsics[..., 1, -1] = ty
+        extrinsics[..., 2, -1] = tz
+        extrinsics[:3, :3] = R
+
+        extrinsics_batch.append(extrinsics)
+    return torch.stack(extrinsics_batch)
+
+
+def create_pinhole_camera(height: float, width: float, device: Device, dtype: torch.dtype) -> PinholeCamera:
+    """Create a single PinholeCamera with default parameters.
+
+    Args:
+        height: Camera image height
+        width: Camera image width
+        device: Device for tensors
+        dtype: Data type for tensors
+
+    Returns:
+        PinholeCamera: A PinholeCamera instance
+    """
+    fx = width
+    fy = height
+    cx = (width - 1.0) / 2.0
+    cy = (height - 1.0) / 2.0
+
+    tx = 0.0
+    ty = 0.0
+    tz = 1.0
+
+    alpha = math.pi / 2.0
+    beta = 0.0
+    gamma = -math.pi / 2.0
+
+    intrinsics = create_intrinsics([fx], [fy], [cx], [cy], device=device, dtype=dtype)
+    extrinsics = create_extrinsics_with_rotation([alpha], [beta], [gamma], [tx], [ty], [tz], device=device, dtype=dtype)
+
+    return PinholeCamera(
+        intrinsics,
+        extrinsics,
+        torch.tensor([height], device=device, dtype=dtype),
+        torch.tensor([width], device=device, dtype=dtype),
+    )
+
+
+def create_four_cameras(device: Device, dtype: torch.dtype) -> PinholeCamera:
+    """Create four PinholeCameras with predefined parameters.
+
+    Args:
+        device: Device for tensors
+        dtype: Data type for tensors
+
+    Returns:
+        PinholeCamera: A PinholeCamera instance with 4 cameras in batch
+    """
+    height = torch.tensor([5, 4, 4, 4], device=device, dtype=dtype)
+    width = torch.tensor([9, 7, 7, 7], device=device, dtype=dtype)
+
+    fx = width.tolist()
+    fy = height.tolist()
+
+    cx = (width - 1.0) / 2.0
+    cy = (height - 1.0) / 2.0
+
+    tx = [0.0, 0.0, 0.0, 0.0]
+    ty = [0.0, 0.0, 0.0, 0.0]
+    tz = [11.0, 11.0, 11.0, 5.0]
+
+    pi = math.pi
+    alpha = [pi / 2.0, pi / 2.0, pi / 2.0, 0.0]
+    beta = [0.0, 0.0, 0.0, pi]
+    gamma = [-pi / 2.0, 0.0, pi / 2.0, 0.0]
+
+    intrinsics = create_intrinsics(fx, fy, cx, cy, device=device, dtype=dtype)
+    extrinsics = create_extrinsics_with_rotation(alpha, beta, gamma, tx, ty, tz, device=device, dtype=dtype)
+
+    cameras = PinholeCamera(intrinsics, extrinsics, height, width)
+    return cameras
+
+
+def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
+    """Creates random images for a given set of cameras."""
+    torch.manual_seed(112)
+    imgs: list[Tensor] = []
+    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
+        image_data = torch.randint(0, 255, (3, int(height), int(width)), dtype=torch.uint8)  # (C, H, W)
+        imgs.append(image_data)  # (C, H, W)
+    return imgs
+
+
+def create_red_images_for_cameras(cameras: PinholeCamera, device: Device) -> list[Tensor]:
+    """Creates red images for a given set of cameras."""
+    imgs: list[Tensor] = []
+    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
+        image_data = torch.zeros(3, int(height), int(width), dtype=torch.uint8)  # (C, H, W)
+        image_data[0, ...] = 255  # Red channel
+        imgs.append(image_data.to(device=device))
+    return imgs

--- a/kornia/geometry/camera/utils.py
+++ b/kornia/geometry/camera/utils.py
@@ -226,7 +226,7 @@ def create_four_cameras(device: Device, dtype: torch.dtype) -> PinholeCamera:
 
 
 def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
-    """Creates random images for a given set of cameras."""
+    """Create random images for a given set of cameras."""
     torch.manual_seed(112)
     imgs: list[Tensor] = []
     for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
@@ -236,7 +236,7 @@ def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
 
 
 def create_red_images_for_cameras(cameras: PinholeCamera, device: Device) -> list[Tensor]:
-    """Creates red images for a given set of cameras."""
+    """Create red images for a given set of cameras."""
     imgs: list[Tensor] = []
     for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
         image_data = torch.zeros(3, int(height), int(width), dtype=torch.uint8)  # (C, H, W)

--- a/kornia/geometry/depth.py
+++ b/kornia/geometry/depth.py
@@ -171,8 +171,9 @@ def depth_to_3d(depth: Tensor, camera_matrix: Tensor, normalize_points: bool = F
 
     # create base coordinates grid
     _, _, height, width = depth.shape
-    points_2d: Tensor = create_meshgrid(height, width, normalized_coordinates=False)  # 1xHxWx2
-    points_2d = points_2d.to(depth.device).to(depth.dtype)
+    points_2d: Tensor = create_meshgrid(
+        height, width, normalized_coordinates=False, device=depth.device, dtype=depth.dtype
+    )  # 1xHxWx2
 
     # depth should come in Bx1xHxW
     points_depth: Tensor = depth.permute(0, 2, 3, 1)  # 1xHxWx1

--- a/kornia/geometry/epipolar/__init__.py
+++ b/kornia/geometry/epipolar/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Epipolar — Epipolar geometry operations for Kornia.
+
+This subpackage provides functions for epipolar distance, fundamental matrices, and stereo vision.
+"""
+
 from ._metrics import (
     left_to_right_epipolar_distance,
     right_to_left_epipolar_distance,

--- a/kornia/geometry/epipolar/__init__.py
+++ b/kornia/geometry/epipolar/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Epipolar — Epipolar geometry operations for Kornia.
+"""Kornia Geometry Epipolar — Epipolar geometry operations for Kornia.
 
 This subpackage provides functions for epipolar distance, fundamental matrices, and stereo vision.
 """

--- a/kornia/geometry/liegroup/__init__.py
+++ b/kornia/geometry/liegroup/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Lie Group — Lie group operations for Kornia.
+"""Kornia Geometry Lie Group — Lie group operations for Kornia.
 
 This subpackage provides SE2, SE3, SO2, and related Lie group classes and utilities.
 """

--- a/kornia/geometry/liegroup/__init__.py
+++ b/kornia/geometry/liegroup/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Lie Group — Lie group operations for Kornia.
+
+This subpackage provides SE2, SE3, SO2, and related Lie group classes and utilities.
+"""
+
 from .se2 import Se2
 from .se3 import Se3
 from .so2 import So2

--- a/kornia/geometry/solvers/__init__.py
+++ b/kornia/geometry/solvers/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Solvers — Polynomial and geometric solvers for Kornia.
+
+This subpackage provides polynomial solvers and related utilities for geometry tasks.
+"""
+
 from .polynomial_solver import (
     determinant_to_polynomial,
     multiply_deg_one_poly,

--- a/kornia/geometry/solvers/__init__.py
+++ b/kornia/geometry/solvers/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Solvers — Polynomial and geometric solvers for Kornia.
+"""Kornia Geometry Solvers — Polynomial and geometric solvers for Kornia.
 
 This subpackage provides polynomial solvers and related utilities for geometry tasks.
 """

--- a/kornia/geometry/subpix/__init__.py
+++ b/kornia/geometry/subpix/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Subpix — Subpixel operations for Kornia.
+"""Kornia Geometry Subpix — Subpixel operations for Kornia.
 
 This subpackage provides subpixel localization and softmax utilities for geometry tasks.
 """

--- a/kornia/geometry/subpix/__init__.py
+++ b/kornia/geometry/subpix/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Subpix — Subpixel operations for Kornia.
+
+This subpackage provides subpixel localization and softmax utilities for geometry tasks.
+"""
+
 from __future__ import annotations
 
 from .dsnt import render_gaussian2d, spatial_expectation2d, spatial_softmax2d

--- a/kornia/geometry/subpix/dsnt.py
+++ b/kornia/geometry/subpix/dsnt.py
@@ -118,10 +118,6 @@ def spatial_expectation2d(input: Tensor, normalized_coordinates: bool = True) ->
     return output.view(batch_size, channels, 2)  # BxNx2
 
 
-def _safe_zero_division(numerator: Tensor, denominator: Tensor, eps: float = 1e-32) -> Tensor:
-    return numerator / torch.clamp(denominator, min=eps)
-
-
 def render_gaussian2d(mean: Tensor, std: Tensor, size: tuple[int, int], normalized_coordinates: bool = True) -> Tensor:
     r"""Render the PDF of a 2D Gaussian distribution.
 
@@ -141,32 +137,40 @@ def render_gaussian2d(mean: Tensor, std: Tensor, size: tuple[int, int], normaliz
         raise TypeError("Expected inputs to have the same dtype and device")
 
     height, width = size
+    dtype = mean.dtype
+    device = mean.device
 
-    # Create coordinates grid.
-    grid = create_meshgrid(height, width, normalized_coordinates, mean.device)
-    grid = grid.to(mean.dtype)
-    pos_x = grid[..., 0].view(height, width)
-    pos_y = grid[..., 1].view(height, width)
+    # Create coordinates vectors.
+    if normalized_coordinates:
+        xs = torch.linspace(-1, 1, width, device=device, dtype=dtype)
+        ys = torch.linspace(-1, 1, height, device=device, dtype=dtype)
+    else:
+        xs = torch.linspace(0, width - 1, width, device=device, dtype=dtype)
+        ys = torch.linspace(0, height - 1, height, device=device, dtype=dtype)
+
+    mu_x = mean[..., 0].unsqueeze(-1)
+    mu_y = mean[..., 1].unsqueeze(-1)
+    sigma_x = std[..., 0].unsqueeze(-1)
+    sigma_y = std[..., 1].unsqueeze(-1)
 
     # Gaussian PDF = exp(-(x - \mu)^2 / (2 \sigma^2))
     #              = exp(dists * ks),
     #                where dists = (x - \mu)^2 and ks = -1 / (2 \sigma^2)
 
     # dists <- (x - \mu)^2
-    dist_x = (pos_x - mean[..., 0, None, None]) ** 2
-    dist_y = (pos_y - mean[..., 1, None, None]) ** 2
+    dist_x_sq = (xs - mu_x) ** 2
+    dist_y_sq = (ys - mu_y) ** 2
 
     # ks <- -1 / (2 \sigma^2)
-    k_x = -0.5 * torch.reciprocal(std[..., 0, None, None])
-    k_y = -0.5 * torch.reciprocal(std[..., 1, None, None])
+    k_x = -0.5 * torch.reciprocal(sigma_x**2)
+    k_y = -0.5 * torch.reciprocal(sigma_y**2)
 
     # Assemble the 2D Gaussian.
-    exps_x = torch.exp(dist_x * k_x)
-    exps_y = torch.exp(dist_y * k_y)
-    gauss = exps_x * exps_y
+    gauss_x = torch.exp(dist_x_sq * k_x)
+    gauss_y = torch.exp(dist_y_sq * k_y)
 
     # Rescale so that values sum to one.
-    val_sum = gauss.sum(-2, keepdim=True).sum(-1, keepdim=True)
-    gauss = _safe_zero_division(gauss, val_sum)
+    gauss_x = gauss_x / (gauss_x.sum(dim=-1, keepdim=True) + 1e-8)
+    gauss_y = gauss_y / (gauss_y.sum(dim=-1, keepdim=True) + 1e-8)
 
-    return gauss
+    return gauss_y.unsqueeze(-1) * gauss_x.unsqueeze(-2)

--- a/kornia/geometry/transform/__init__.py
+++ b/kornia/geometry/transform/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""
+Kornia Geometry Transform — Geometric transformation operations for Kornia.
+
+This subpackage provides affine, crop, and other geometric transformation utilities.
+"""
+
 from .affwarp import *
 from .crop2d import *
 from .crop3d import *

--- a/kornia/geometry/transform/__init__.py
+++ b/kornia/geometry/transform/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Geometry Transform — Geometric transformation operations for Kornia.
+"""Kornia Geometry Transform — Geometric transformation operations for Kornia.
 
 This subpackage provides affine, crop, and other geometric transformation utilities.
 """

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -166,12 +166,15 @@ def affine(
 
     """
     # warping needs data in the shape of BCHW
-    is_unbatched: bool = tensor.ndimension() == 3
+    is_unbatched: bool = tensor.dim() == 3
     if is_unbatched:
         tensor = torch.unsqueeze(tensor, dim=0)
 
     # we enforce broadcasting since by default grid_sample it does not
     # give support for that
+    if tensor.shape[0] == 1 and matrix.shape[0] != 1:
+        tensor = tensor.expand(matrix.shape[0], tensor.shape[1], tensor.shape[2], tensor.shape[3])
+
     matrix = matrix.expand(tensor.shape[0], -1, -1)
 
     # warp the input tensor
@@ -217,7 +220,7 @@ def affine3d(
 
     """
     # warping needs data in the shape of BCDHW
-    is_unbatched: bool = tensor.ndimension() == 4
+    is_unbatched: bool = tensor.dim() == 4
     if is_unbatched:
         tensor = torch.unsqueeze(tensor, dim=0)
 

--- a/kornia/geometry/transform/affwarp.py
+++ b/kornia/geometry/transform/affwarp.py
@@ -774,9 +774,9 @@ class Affine(Module):
             must have a shape of (B), where B is the batch size.
         translation: Amount of pixels for translation in x- and y-direction. The tensor must
             have a shape of (B, 2), where B is the batch size and the last dimension contains dx and dy.
-        scale_factor: Factor for scaling. The tensor must have a shape of (B), where B is the
-            batch size.
-        shear: Angles in degrees for shearing in x- and y-direction around the center. The
+        scale_factor: Factor for scaling. The tensor must have a shape of (B,2), where B is the
+            batch size and the last dimension contains scale factors for x and y direction.
+        shear: Factor for shearing in x- and y-direction around the center. The
             tensor must have a shape of (B, 2), where B is the batch size and the last dimension contains sx and sy.
         center: Transformation center in pixels. The tensor must have a shape of (B, 2), where
             B is the batch size and the last dimension contains cx and cy. Defaults to the center of image to be

--- a/kornia/grad_estimator/__init__.py
+++ b/kornia/grad_estimator/__init__.py
@@ -15,8 +15,7 @@
 # limitations under the License.
 #
 
-"""
-Kornia Grad Estimator — Gradient estimation utilities for Kornia.
+"""Kornia Grad Estimator — Gradient estimation utilities for Kornia.
 
 This subpackage provides straight-through estimators and related functions.
 """

--- a/kornia/grad_estimator/__init__.py
+++ b/kornia/grad_estimator/__init__.py
@@ -15,4 +15,10 @@
 # limitations under the License.
 #
 
+"""
+Kornia Grad Estimator — Gradient estimation utilities for Kornia.
+
+This subpackage provides straight-through estimators and related functions.
+"""
+
 from .ste import STEFunction, StraightThroughEstimator

--- a/kornia/image/__init__.py
+++ b/kornia/image/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""Image submodule for Kornia.
+
+This package provides image data structures and utilities, including image layout, size, pixel format,
+and channel order definitions.
+"""
+
 from .base import ChannelsOrder, ImageLayout, ImageSize, PixelFormat
 from .image import Image
 

--- a/kornia/image/image.py
+++ b/kornia/image/image.py
@@ -188,7 +188,7 @@ class Image:
         return self
 
     def to_gray(self) -> Image:
-        """Converts the image to grayscale."""
+        """Convert the image to grayscale."""
         src = self._pixel_format.color_space
         data = self._data
 
@@ -220,7 +220,7 @@ class Image:
         return Image(out, new_pf, new_layout)
 
     def to_rgb(self) -> Image:
-        """Converts the image to RGB."""
+        """Convert the image to RGB."""
         src = self._pixel_format.color_space
         data = self._data
 
@@ -246,7 +246,7 @@ class Image:
         return Image(out, new_pf, new_layout)
 
     def to_bgr(self) -> Image:
-        """Converts the image to BGR."""
+        """Convert the image to BGR."""
         src = self._pixel_format.color_space
         data = self._data
 

--- a/kornia/io/__init__.py
+++ b/kornia/io/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""IO submodule for Kornia.
+
+This package provides image input/output utilities, including image loading and writing functions.
+"""
+
 from .io import ImageLoadType, load_image, write_image
 
 __all__ = ["ImageLoadType", "load_image", "write_image"]

--- a/kornia/losses/__init__.py
+++ b/kornia/losses/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""Losses submodule for Kornia.
+
+This package provides a collection of loss functions for computer vision tasks, including SSIM,
+PSNR, Dice, Focal, Lovasz, and more.
+"""
+
 from __future__ import annotations
 
 from .cauchy import CauchyLoss, cauchy_loss

--- a/kornia/metrics/__init__.py
+++ b/kornia/metrics/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""Metrics submodule for Kornia.
+
+This package provides evaluation metrics for computer vision, such as accuracy, mean IoU,
+PSNR, SSIM, and endpoint error.
+"""
+
 from .accuracy import accuracy
 from .average_meter import AverageMeter
 from .confusion_matrix import confusion_matrix

--- a/kornia/models/__init__.py
+++ b/kornia/models/__init__.py
@@ -15,6 +15,12 @@
 # limitations under the License.
 #
 
+"""Models submodule for Kornia.
+
+This package provides model architectures and utilities for tasks such as depth estimation,
+detection, segmentation, super-resolution, and tracking.
+"""
+
 from . import (
     depth_estimation,
     detection,

--- a/kornia/models/depth_estimation/__init__.py
+++ b/kornia/models/depth_estimation/__init__.py
@@ -15,5 +15,10 @@
 # limitations under the License.
 #
 
+"""Depth estimation models submodule for Kornia.
+
+This package provides model architectures and utilities for monocular depth estimation tasks.
+"""
+
 from .base import *
 from .depth_anything import *

--- a/kornia/models/detection/__init__.py
+++ b/kornia/models/detection/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Detection models submodule for Kornia.
+
+This package provides model architectures and utilities for object detection tasks.
+"""
+
 from .base import *
 from .rtdetr import *
 from .utils import *

--- a/kornia/models/edge_detection/__init__.py
+++ b/kornia/models/edge_detection/__init__.py
@@ -15,5 +15,10 @@
 # limitations under the License.
 #
 
+"""Edge detection models submodule for Kornia.
+
+This package provides model architectures and utilities for edge detection tasks.
+"""
+
 from .base import *
 from .dexined import *

--- a/kornia/models/segmentation/__init__.py
+++ b/kornia/models/segmentation/__init__.py
@@ -15,5 +15,10 @@
 # limitations under the License.
 #
 
+"""Segmentation models submodule for Kornia.
+
+This package provides model architectures and utilities for image segmentation tasks.
+"""
+
 from .base import *
 from .segmentation_models import *

--- a/kornia/models/super_resolution/__init__.py
+++ b/kornia/models/super_resolution/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Super-resolution models submodule for Kornia.
+
+This package provides model architectures and utilities for image super-resolution tasks.
+"""
+
 from .base import *
 from .rrdbnet import *
 from .small_sr import *

--- a/kornia/models/tracking/__init__.py
+++ b/kornia/models/tracking/__init__.py
@@ -15,4 +15,9 @@
 # limitations under the License.
 #
 
+"""Tracking models submodule for Kornia.
+
+This package provides model architectures and utilities for object tracking tasks.
+"""
+
 from .boxmot_tracker import *

--- a/kornia/morphology/__init__.py
+++ b/kornia/morphology/__init__.py
@@ -15,4 +15,9 @@
 # limitations under the License.
 #
 
+"""Morphology submodule for Kornia.
+
+This package provides morphological operations for image processing tasks.
+"""
+
 from .morphology import *

--- a/kornia/nerf/__init__.py
+++ b/kornia/nerf/__init__.py
@@ -14,3 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""Neural Radiance Fields (NeRF) submodule for Kornia.
+
+This package provides utilities and models for NeRF-based 3D scene representation and rendering.
+"""

--- a/kornia/onnx/__init__.py
+++ b/kornia/onnx/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""ONNX submodule for Kornia.
+
+This package provides utilities and modules for ONNX export and integration.
+"""
+
 from .module import *
 from .sequential import *
 from .utils import *

--- a/kornia/sensors/__init__.py
+++ b/kornia/sensors/__init__.py
@@ -14,3 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""Sensors submodule for Kornia.
+
+This package provides utilities and modules for sensor data processing and integration.
+"""

--- a/kornia/sensors/camera/__init__.py
+++ b/kornia/sensors/camera/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Camera models submodule for Kornia sensors.
+
+This package provides camera model definitions and utilities for camera calibration and projection.
+"""
+
 from .camera_model import (
     BrownConradyModel,
     CameraModel,

--- a/kornia/tracking/__init__.py
+++ b/kornia/tracking/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Tracking submodule for Kornia.
+
+This package provides tracking algorithms and utilities, including planar homography tracking.
+"""
+
 from .planar_tracker import HomographyTracker
 
 __all__ = ["HomographyTracker"]

--- a/kornia/transpiler/__init__.py
+++ b/kornia/transpiler/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Transpiler submodule for Kornia.
+
+This package provides utilities to transpile Kornia operations to other frameworks such as JAX, NumPy, and TensorFlow.
+"""
+
 from .transpiler import to_jax, to_numpy, to_tensorflow
 
 __all__ = ["to_jax", "to_numpy", "to_tensorflow"]

--- a/kornia/utils/__init__.py
+++ b/kornia/utils/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Utils submodule for Kornia.
+
+This package provides utility functions and helpers for image processing, device management, data conversion, and more.
+"""
+
 from ._compat import torch_meshgrid
 from .download import CachedDownloader
 from .draw import draw_convex_polygon, draw_line, draw_point2d, draw_rectangle

--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -54,7 +54,7 @@ def draw_point2d(image: Tensor, points: Tensor, color: Tensor) -> Tensor:
 
 
 def _draw_pixel(image: torch.Tensor, x: int, y: int, color: torch.Tensor) -> None:
-    r"""Draws a pixel into an image.
+    r"""Draw a pixel into an image.
 
     Args:
         image: the input image to where to draw the lines with shape :math`(C,H,W)`.

--- a/kornia/utils/draw.py
+++ b/kornia/utils/draw.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""Utilities for drawing on images."""
 
 from typing import List, Optional, Tuple, Union
 

--- a/kornia/utils/sample.py
+++ b/kornia/utils/sample.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+"""Utilities for downloading and loading sample images."""
 
 import logging
 import os

--- a/kornia/x/__init__.py
+++ b/kornia/x/__init__.py
@@ -15,6 +15,11 @@
 # limitations under the License.
 #
 
+"""Experimental submodule (x) for Kornia.
+
+This package provides experimental features, trainers, callbacks, and utilities for advanced workflows.
+"""
+
 from .callbacks import EarlyStopping, ModelCheckpoint
 from .trainer import Trainer
 from .trainers import ImageClassifierTrainer, ObjectDetectionTrainer, SemanticSegmentationTrainer

--- a/testing/nerf.py
+++ b/testing/nerf.py
@@ -1,0 +1,26 @@
+# LICENSE HEADER MANAGED BY add-license-header
+#
+# Copyright 2018 Kornia Team
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+# Shim imports for backward compatibility - implementations moved to kornia.geometry.camera.utils
+from kornia.geometry.camera.utils import (
+    create_pinhole_camera,
+)
+
+# Deprecated alias for backward compatibility - use create_pinhole_camera instead
+create_one_camera = create_pinhole_camera

--- a/tests/core/test_tensor_wrapper.py
+++ b/tests/core/test_tensor_wrapper.py
@@ -43,7 +43,7 @@ class TestTensorWrapper(BaseTester):
         torch.save(tensor, file_path)
         file_path.is_file()
 
-        loaded_tensor: TensorWrapper = torch.load(file_path)
+        loaded_tensor: TensorWrapper = torch.load(file_path, weights_only=False)
         assert isinstance(loaded_tensor, TensorWrapper)
 
         self.assert_close(loaded_tensor.unwrap(), tensor.unwrap())

--- a/tests/geometry/subpix/test_dsnt.py
+++ b/tests/geometry/subpix/test_dsnt.py
@@ -26,29 +26,35 @@ from testing.base import assert_close
 class TestRenderGaussian2d:
     @pytest.fixture()
     def gaussian(self, device, dtype):
-        return torch.tensor(
-            [
-                [0.002969, 0.013306, 0.021938, 0.013306, 0.002969],
-                [0.013306, 0.059634, 0.098320, 0.059634, 0.013306],
-                [0.021938, 0.098320, 0.162103, 0.098320, 0.021938],
-                [0.013306, 0.059634, 0.098320, 0.059634, 0.013306],
-                [0.002969, 0.013306, 0.021938, 0.013306, 0.002969],
-            ],
-            dtype=dtype,
-            device=device,
-        )
+        # For a standard gaussian on 5 points [-1, -0.5, 0, 0.5, 1] with std=0.25
+        # The equation is exp( -x^2 / (2 * std^2) ) -> exp( -x^2 * 8 )
+        # x=0   -> exp(0)  = 1.0
+        # x=0.5 -> exp(-2) ≈ 0.135335
+        # x=1.0 -> exp(-8) ≈ 0.000335
 
-    def test_pixel_coordinates(self, gaussian, device, dtype):
-        mean = torch.tensor([2.0, 2.0], dtype=dtype, device=device)
-        std = torch.tensor([1.0, 1.0], dtype=dtype, device=device)
-        actual = kornia.geometry.subpix.render_gaussian2d(mean, std, (5, 5), False)
-        assert_close(actual, gaussian, rtol=0, atol=1e-4)
+        vec = torch.tensor([0.00033546, 0.13533528, 1.00000000, 0.13533528, 0.00033546], device=device, dtype=dtype)
+
+        # Create 2D from 1D (Outer Product)
+        grid = vec.unsqueeze(1) * vec.unsqueeze(0)
+
+        # Normalize sum to 1
+        return grid / grid.sum()
 
     def test_normalized_coordinates(self, gaussian, device, dtype):
         mean = torch.tensor([0.0, 0.0], dtype=dtype, device=device)
         std = torch.tensor([0.25, 0.25], dtype=dtype, device=device)
-        actual = kornia.geometry.subpix.render_gaussian2d(mean, std, (5, 5), True)
-        assert_close(actual, gaussian, rtol=0, atol=1e-4)
+
+        actual = kornia.geometry.subpix.render_gaussian2d(mean.view(1, 2), std.view(1, 2), (5, 5), True)
+
+        assert_close(actual[0], gaussian, rtol=1e-5, atol=1e-5)
+
+    def test_pixel_coordinates(self, gaussian, device, dtype):
+        mean = torch.tensor([2.0, 2.0], dtype=dtype, device=device)
+        std = torch.tensor([0.5, 0.5], dtype=dtype, device=device)
+
+        actual = kornia.geometry.subpix.render_gaussian2d(mean.view(1, 2), std.view(1, 2), (5, 5), False)
+
+        assert_close(actual[0], gaussian, rtol=1e-5, atol=1e-5)
 
     def test_dynamo(self, device, dtype, torch_optimizer):
         mean = torch.tensor([0.0, 0.0], dtype=dtype, device=device)
@@ -57,7 +63,10 @@ class TestRenderGaussian2d:
         op = kornia.geometry.subpix.render_gaussian2d
         op_optimized = torch_optimizer(op)
 
-        assert_close(op(mean, std, (5, 5), True), op_optimized(mean, std, (5, 5), True))
+        res_orig = op(mean.view(1, 2), std.view(1, 2), (5, 5), True)
+        res_opt = op_optimized(mean.view(1, 2), std.view(1, 2), (5, 5), True)
+
+        assert_close(res_orig, res_opt)
 
 
 class TestSpatialSoftmax2d:

--- a/tests/nerf/test_data_utils.py
+++ b/tests/nerf/test_data_utils.py
@@ -17,35 +17,10 @@
 
 from __future__ import annotations
 
-import torch
-
-from kornia.core import Device, Tensor
-from kornia.geometry.camera import PinholeCamera
+from kornia.geometry.camera.utils import create_four_cameras, create_random_images_for_cameras
 from kornia.nerf.data_utils import RayDataset, instantiate_ray_dataloader
 
 from testing.base import assert_close
-
-from tests.nerf.test_rays import create_four_cameras
-
-
-def create_random_images_for_cameras(cameras: PinholeCamera) -> list[Tensor]:
-    """Creates random images for a given set of cameras."""
-    torch.manual_seed(112)
-    imgs: list[Tensor] = []
-    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
-        image_data = torch.randint(0, 255, (3, int(height), int(width)), dtype=torch.uint8)  # (C, H, W)
-        imgs.append(image_data)  # (C, H, W)
-    return imgs
-
-
-def create_red_images_for_cameras(cameras: PinholeCamera, device: Device) -> list[Tensor]:
-    """Creates red images for a given set of cameras."""
-    imgs: list[Tensor] = []
-    for height, width in zip(cameras.height.tolist(), cameras.width.tolist()):
-        image_data = torch.zeros(3, int(height), int(width), dtype=torch.uint8)  # (C, H, W)
-        image_data[0, ...] = 255  # Red channel
-        imgs.append(image_data.to(device=device))
-    return imgs
 
 
 class TestDataset:

--- a/tests/nerf/test_nerf_solver.py
+++ b/tests/nerf/test_nerf_solver.py
@@ -20,13 +20,16 @@ import torch
 
 from kornia.core import Tensor
 from kornia.geometry.camera import PinholeCamera
+from kornia.geometry.camera.utils import (
+    create_four_cameras,
+    create_pinhole_camera,
+    create_random_images_for_cameras,
+    create_red_images_for_cameras,
+)
 from kornia.nerf.nerf_model import NerfModelRenderer
 from kornia.nerf.nerf_solver import NerfSolver
 
 from testing.base import assert_close
-
-from tests.nerf.test_data_utils import create_random_images_for_cameras, create_red_images_for_cameras
-from tests.nerf.test_rays import create_four_cameras, create_one_camera
 
 
 class TestNerfSolver:
@@ -50,7 +53,7 @@ class TestNerfSolver:
 
     def test_only_red_uniform_sampling(self, device, dtype):
         torch.manual_seed(1)  # For reproducibility of random processes
-        camera: PinholeCamera = create_one_camera(5, 9, device, dtype)
+        camera: PinholeCamera = create_pinhole_camera(5, 9, device, dtype)
         img: list[Tensor] = create_red_images_for_cameras(camera, device)
 
         # train the model
@@ -65,7 +68,7 @@ class TestNerfSolver:
         assert_close(img_rendered.to(device, dtype), img[0].to(device, dtype) / 255.0)
 
     def test_single_ray(self, device, dtype):
-        camera: PinholeCamera = create_one_camera(5, 9, device, dtype)
+        camera: PinholeCamera = create_pinhole_camera(5, 9, device, dtype)
         img: list[Tensor] = create_red_images_for_cameras(camera, device)
 
         nerf_obj = NerfSolver(device=device, dtype=dtype)
@@ -75,7 +78,7 @@ class TestNerfSolver:
     def test_only_red(self, device, dtype):
         torch.manual_seed(0)  # For reproducibility of random processes
 
-        camera: PinholeCamera = create_one_camera(5, 9, device, dtype)
+        camera: PinholeCamera = create_pinhole_camera(5, 9, device, dtype)
         img: list[Tensor] = create_red_images_for_cameras(camera, device)
 
         # train the model


### PR DESCRIPTION
## Description
This PR fixes the CI test failures by addressing two issues:

1. **Missing HuggingFace Authentication**: Adds support for HuggingFace Hub token authentication in the GitHub Actions workflow to enable downloading gated/private models
2. **Unavailable SD 2.1 Model**: Replaces the discontinued `stabilityai/stable-diffusion-2-1` model with `stabilityai/stable-diffusion-xl-base-1.0`

## Changes Made

### GitHub Actions
- Added `huggingface-token` input parameter to `.github/actions/tests/action.yml`
- Set `HF_TOKEN` environment variable for pytest runs
- Pass `HUGGING_FACE_HUB_TOKEN` secret from workflow to tests action

### Model Updates
- Replaced `stabilityai/stable-diffusion-2-1` with `stabilityai/stable-diffusion-xl-base-1.0` in `kornia/filters/dissolving.py`
- Added support for "xl" version parameter
- Updated documentation to reflect SD-XL as replacement for SD 2.1

## Testing
- Verified HuggingFace token authentication works with `huggingface_hub.HfApi.whoami()`
- Confirmed SD-XL model is available and not gated
- Tested SD-XL model can be downloaded with the token

## Fixes
- Resolves CI test failures in `tests/augmentation/test_augmentation.py::TestRandomDissolving`
- Resolves CI test failures in `tests/filters/test_dissolving.py::TestStableDiffusionDissolving`